### PR TITLE
Make dbcUsername/Password/ApiUrl optional (only required if plugin is being used)

### DIFF
--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -26,9 +26,9 @@ object DatabricksPlugin extends AutoPlugin {
     val dbcListClusters = taskKey[Unit]("List all available clusters and their states.")
     val dbcRestartClusters = taskKey[Unit]("Restart the given clusters.")
 
-    val dbcApiUrl = settingKey[String]("The URL for the DB API endpoint")
-    val dbcUsername = settingKey[String]("The username for Databricks Cloud")
-    val dbcPassword = settingKey[String]("The password for Databricks Cloud")
+    val dbcApiUrl = taskKey[String]("The URL for the DB API endpoint")
+    val dbcUsername = taskKey[String]("The username for Databricks Cloud")
+    val dbcPassword = taskKey[String]("The password for Databricks Cloud")
 
     final val DBC_ALL_CLUSTERS = "ALL_CLUSTERS"
   }
@@ -184,6 +184,36 @@ object DatabricksPlugin extends AutoPlugin {
   }
 
   val baseDBCSettings: Seq[Setting[_]] = Seq(
+    dbcUsername := { 
+      sys.error(
+        """
+          |dbcUsername not defined. Please make sure to add these keys to your build:
+          |  dbcUsername := "user"
+          |  dbcPassword := "pass"
+          |  dbcApiUrl := "https://organization.cloud.databricks.com:34563/api/1.1"
+          |  See the sbt-databricks README for more info.
+        """.stripMargin)
+    },
+    dbcPassword := { 
+      sys.error(
+        """
+          |dbcPassword not defined. Please make sure to add these keys to your build:
+          |  dbcUsername := "user"
+          |  dbcPassword := "pass"
+          |  dbcApiUrl := "https://organization.cloud.databricks.com:34563/api/1.1"
+          |  See the sbt-databricks README for more info.
+        """.stripMargin)
+    },
+    dbcApiUrl := { 
+      sys.error(
+        """
+          |dbcApiUrl not defined. Please make sure to add these keys to your build:
+          |  dbcUsername := "user"
+          |  dbcPassword := "pass"
+          |  dbcApiUrl := "https://organization.cloud.databricks.com:34563/api/1.1"
+          |  See the sbt-databricks README for more info.
+        """.stripMargin)
+    },
     dbcClusters := Seq.empty[String],
     dbcRestartOnAttach := true,
     dbcLibraryPath := "/",

--- a/src/sbt-test/sbt-databricks/classpath/build.sbt
+++ b/src/sbt-test/sbt-databricks/classpath/build.sbt
@@ -14,8 +14,6 @@ lazy val dbcSettings: Seq[Setting[_]] = Seq(
   dbcPassword := "test"
 )
 
-dbcSettings
-
 lazy val projA = Project(
   base = file("multi-a"),
   id = "multi-a",
@@ -46,6 +44,12 @@ lazy val projB = Project(
       checkJar(everything, "multi-a_2.10-0.1.jar")
       checkJar(everything, "spark-csv_2.10-1.0.0.jar")
     }) ++ dbcSettings)
+
+// This project does not use the plugin, nor does it define dbcSettings,
+// but it should still compile successfully.
+lazy val projC = Project(
+  base = file("multi-c"),
+  id = "multi-b")
 
 def checkJar(classpath: Seq[String], jar: String): Unit = {
   if (!classpath.contains(jar)) sys.error(s"$jar not found in classpath")

--- a/src/sbt-test/sbt-databricks/classpath/build.sbt
+++ b/src/sbt-test/sbt-databricks/classpath/build.sbt
@@ -49,7 +49,7 @@ lazy val projB = Project(
 // but it should still compile successfully.
 lazy val projC = Project(
   base = file("multi-c"),
-  id = "multi-b")
+  id = "multi-c")
 
 def checkJar(classpath: Seq[String], jar: String): Unit = {
   if (!classpath.contains(jar)) sys.error(s"$jar not found in classpath")


### PR DESCRIPTION
Because this is an AutoPlugin, it is included in all projects by default. With a complex, multi-project build, it may be annoying to define the task for every project in order to prevent a compile error. This moves the error to become a runtime error when using the plugin, which may be slightly more annoying to users but should be tempered by the README and the error message itself.