### PR TITLE
Allow overriding dbcClasspath, to enable pushing assembly jars

### DIFF
--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -38,6 +38,8 @@ object DatabricksPlugin extends AutoPlugin {
   // exposed for testing
   val dbcApiClient = taskKey[DatabricksHttp]("Create client to handle SSL communication.")
 
+  val dbcClasspath = taskKey[Seq[File]]("Defines the dependencies (jars) which should be uploaded.")
+
   override def requires = plugins.JvmPlugin
   override def trigger = allRequirements
 
@@ -67,12 +69,6 @@ object DatabricksPlugin extends AutoPlugin {
         }
       }
     }.flatMap(c => c)
-  }
-
-  /** Returns all the jars related to this library. */
-  lazy val dbcClasspath = Def.task {
-    (dbcLocalProjects.value ++ (managedClasspath in Runtime).value.files
-      ).filterNot(_.getName startsWith "scala-")
   }
 
   /**
@@ -219,6 +215,11 @@ object DatabricksPlugin extends AutoPlugin {
     dbcLibraryPath := "/",
     dbcApiClient := DatabricksHttp(dbcApiUrl.value, dbcUsername.value, dbcPassword.value),
     dbcFetchClusters := (dbcApiClient.value.fetchClusters, true),
+    // Returns all the jars related to this library.
+    dbcClasspath := {
+      (dbcLocalProjects.value ++ (managedClasspath in Runtime).value.files)
+        .filterNot(_.getName startsWith "scala-")
+    },
     dbcRestartClusters := {
       val onClusters = dbcClusterSet.value
       val (allClusters, _) = dbcFetchClusters.value

--- a/src/sbt-test/sbt-databricks/classpath/build.sbt
+++ b/src/sbt-test/sbt-databricks/classpath/build.sbt
@@ -51,6 +51,26 @@ lazy val projC = Project(
   base = file("multi-c"),
   id = "multi-c")
 
+// Test that dbcClasspath can be overridden to change the pushed jars.
+lazy val projD = Project(
+  base = file("multi-d"),
+  id = "multi-d",
+  settings = Seq(
+    libraryDependencies += "com.databricks" %% "spark-csv" % "1.0.0",
+    dbcClasspath := { 
+      (managedClasspath in Runtime).value.files 
+    },
+    TaskKey[Unit]("checkClasspath") := {
+      val everything = dbcClasspath.value.map(_.getName)
+      checkNotJar(everything, "multi-a_2.10-0.1.jar")
+      checkJar(everything, "spark-csv_2.10-1.0.0.jar")
+    }) ++ dbcSettings)
+
+
 def checkJar(classpath: Seq[String], jar: String): Unit = {
   if (!classpath.contains(jar)) sys.error(s"$jar not found in classpath")
+}
+
+def checkNotJar(classpath: Seq[String], jar: String): Unit = {
+  if (classpath.contains(jar)) sys.error(s"$jar not found classpath")
 }


### PR DESCRIPTION
e.g., `dbcClasspath := { Seq(assembly.value) }`