### PR TITLE
Add support for attachToAllClusters to dbcUpload

### DIFF
--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -51,16 +51,18 @@ class DatabricksHttp(endpoint: String, client: HttpClient, outputStream: PrintSt
   mapper.registerModule(DefaultScalaModule)
 
   /**
-   * Upload a jar to Databrics Cloud
+   * Upload a jar to Databrics Cloud.
    * @param name Name of the library to show on Databricks Cloud
    * @param file The jar file
    * @param folder Where the library should be placed in the file browser in Databricks Cloud
+   * @param attachToAll Whether the library will always be attached to all clusters
    * @return UploadedLibraryId corresponding to the artifact and its LibraryId in Databricks Cloud
    */
   private[sbtdatabricks] def uploadJar(
       name: String,
       file: File,
-      folder: String): UploadedLibraryId = {
+      folder: String,
+      attachToAll: Boolean): UploadedLibraryId = {
     outputStream.println(s"Uploading $name")
     val post = new HttpPost(endpoint + LIBRARY_UPLOAD)
     val entity = new MultipartEntity()
@@ -68,6 +70,7 @@ class DatabricksHttp(endpoint: String, client: HttpClient, outputStream: PrintSt
     entity.addPart("name", new StringBody(name))
     entity.addPart("libType", new StringBody("scala"))
     entity.addPart("folder", new StringBody(folder))
+    entity.addPart("attachToAllClusters", new StringBody(attachToAll.toString))
     entity.addPart("uri", new FileBody(file))
     post.setEntity(entity)
     val response = client.execute(post)

--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -58,7 +58,6 @@ class DatabricksHttp(
    * @param name Name of the library to show on Databricks Cloud
    * @param file The jar file
    * @param folder Where the library should be placed in the file browser in Databricks Cloud
-   * @param attachToAll Whether the library will always be attached to all clusters
    * @return UploadedLibraryId corresponding to the artifact and its LibraryId in Databricks Cloud
    */
   private[sbtdatabricks] def uploadJar(

--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -43,7 +43,10 @@ import sbtdatabricks.DatabricksPlugin.autoImport.DBC_ALL_CLUSTERS
 import sbtdatabricks.util.requests._
 
 /** Collection of REST calls to Databricks Cloud and related helper functions. Exposed for tests */
-class DatabricksHttp(endpoint: String, client: HttpClient, outputStream: PrintStream = System.out) {
+class DatabricksHttp(
+    endpoint: String,
+    val client: HttpClient,
+    outputStream: PrintStream = System.out) {
 
   import DBApiEndpoints._
 
@@ -61,8 +64,7 @@ class DatabricksHttp(endpoint: String, client: HttpClient, outputStream: PrintSt
   private[sbtdatabricks] def uploadJar(
       name: String,
       file: File,
-      folder: String,
-      attachToAll: Boolean): UploadedLibraryId = {
+      folder: String): UploadedLibraryId = {
     outputStream.println(s"Uploading $name")
     val post = new HttpPost(endpoint + LIBRARY_UPLOAD)
     val entity = new MultipartEntity()
@@ -70,7 +72,6 @@ class DatabricksHttp(endpoint: String, client: HttpClient, outputStream: PrintSt
     entity.addPart("name", new StringBody(name))
     entity.addPart("libType", new StringBody("scala"))
     entity.addPart("folder", new StringBody(folder))
-    entity.addPart("attachToAllClusters", new StringBody(attachToAll.toString))
     entity.addPart("uri", new FileBody(file))
     post.setEntity(entity)
     val response = client.execute(post)


### PR DESCRIPTION
Resolves Issue #19 
@jakajancar Could you please help in testing? Thanks!

This PR will make the uploaded jars automatically attach to all clusters when 
`dbcClusters` contains the value `ALL_CLUSTERS` during `dbcUpload`.