### PR TITLE
Two minor README updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,13 @@ addSbtPlugin("com.databricks" %% "sbt-databricks" % "0.1.4")
     addSbtPlugin("com.databricks" %% "sbt-databricks" % "0.1.4")
     ```
 
-2. Set the settings defined [here](#settings) in `~/.sbt/0.13/databricks.sbt`.
+2. Set the settings defined [here](#settings) in `~/.sbt/0.13/databricks.sbt`. You'll have to add the line
+
+    ```
+    import sbtdatabricks.DatabricksPlugin.autoImport._
+    ```
+
+    to that file in order to import this plugin's settings into that configuration file.
 
 Usage
 =====
@@ -104,7 +110,7 @@ dbcClasspath := Seq(assembly.value)
 
 Other optional parameters are:
 ```
-// The location to upload your libraries to in the workspace e.g. "/home"
+// The location to upload your libraries to in the workspace e.g. "/Users/alice"
 dbcLibraryPath := // Default is "/"
 
 // Whether to restart the clusters every time a new version is uploaded to Databricks Cloud


### PR DESCRIPTION
This patch addresses two minor README issues that I ran into while trying to use this plugin:

- Replace `/home` with `/Users/alice` in an example. I think that a lot of users will want to upload files into their home directories, so I wanted the example to reflect the current naming conventions.
- Add instructions on importing plugin's settings in `databricks.sbt` file.