### PR TITLE
Upgrade to jackson-module-scala 2.5.3

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -14,7 +14,7 @@ libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient" % "4.3.3",
     "org.apache.httpcomponents" % "httpmime" % "4.3.3",
     "org.apache.httpcomponents" % "httpclient-cache" % "4.3.3",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.4.2",
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3",
     "commons-fileupload" % "commons-fileupload" % "1.3")
 
 version in ThisBuild := s"${version.value}"


### PR DESCRIPTION
This patch upgrades `jackson-module-scala` from 2.4.2 to 2.5.3.

The motivation for this change is to work around a dependency conflict issue which broke the plugin for me. If another plugin has a transitive dependency on a 2.5.x version of Jackson core but does not depend on the Jackson-scala library, then you can wind up in a situation where a 2.4.x version of the Scala library is used with a 2.5.x version of Jackson, which seems to lead to runtime errors. Specifically, I ran into the following exceptions:

```
com.fasterxml.jackson.databind.JsonMappingException: Could not find creator property with name 'id' (in class sbtdatabricks.LibraryListResult)
 at [Source: java.io.StringReader@6900954e; line: 1, column: 1]
	at com.fasterxml.jackson.databind.JsonMappingException.from(JsonMappingException.java:148)
[..]
```