### PR TITLE
Display error message from JSON when possible

### DIFF
--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -370,6 +370,7 @@ object DatabricksPlugin extends AutoPlugin {
   override lazy val projectSettings: Seq[Setting[_]] = baseDBCSettings
 }
 
+case class ErrorResponse(error: String)
 case class UploadedLibraryId(id: String)
 case class UploadedLibrary(name: String, jar: File, id: String)
 case class Cluster(


### PR DESCRIPTION
This patch modifies `sbt-databricks`' handling of HTTP responses in order to print friendlier error messages. Most of our REST API endpoints return JSON error responses with helpful error messages, so we will now try to display the DBC-specific error messages and fall back to the generic HTTP error descriptions only if we cannot extract an error message from JSON.

As an example:

**Before:** `[error] (foo/*:dbcUpload) org.apache.http.client.HttpResponseException: Server Error`

**After:** `[error] (foo/*:dbcUpload) org.apache.http.client.HttpResponseException: WorkspaceAclExceptions.WorkspacePermissionDeniedException: josh does not have Manage permissions on /. Please contact your administrator for access.` 