### PR TITLE
[Issue #30] Use Jetty 9 HttpClient as client

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,7 @@ language: scala
 scala:
   - 2.10.4
 jdk:
-  - openjdk8
-  - openjdk7
+  - oraclejdk8
 sudo: false
 script:
   - sbt -jvm-opts travis/jvmopts.compile compile

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,8 +2,8 @@ language: scala
 scala:
   - 2.10.4
 jdk:
+  - openjdk8
   - openjdk7
-  - openjdk6
 sudo: false
 script:
   - sbt -jvm-opts travis/jvmopts.compile compile

--- a/build.sbt
+++ b/build.sbt
@@ -11,9 +11,7 @@ version := "0.1.5-SNAPSHOT"
 scalaVersion := "2.10.4"
 
 libraryDependencies ++= Seq(
-    "org.apache.httpcomponents" % "httpclient" % "4.3.3",
-    "org.apache.httpcomponents" % "httpmime" % "4.3.3",
-    "org.apache.httpcomponents" % "httpclient-cache" % "4.3.3",
+    "org.eclipse.jetty" % "jetty-client" % "9.3.7.v20160115",
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3",
     "commons-fileupload" % "commons-fileupload" % "1.3")
 

--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -26,9 +26,8 @@ import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
 
 import org.eclipse.jetty.client.{HttpResponseException, HttpClient}
-import org.eclipse.jetty.client.api.Request
 import org.eclipse.jetty.client.util.BasicAuthentication
-import org.eclipse.jetty.http.{HttpHeader, HttpFields, HttpField}
+import org.eclipse.jetty.http.{HttpHeader, HttpField}
 import org.eclipse.jetty.util.ssl.SslContextFactory
 
 import sbt._

--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -139,7 +139,7 @@ object DatabricksPlugin extends AutoPlugin {
 
   private def uploadImpl1(
       client: DatabricksHttp,
-      folder: String,
+      projectName: String,
       cp: Seq[File],
       existing: Seq[UploadedLibrary]): (Seq[UploadedLibrary], Seq[UploadedLibrary]) = {
     // TODO: try to figure out dependencies with changed versions
@@ -148,8 +148,8 @@ object DatabricksPlugin extends AutoPlugin {
     // Either upload the newer SNAPSHOT versions, or everything, because they don't exist yet.
       val toUpload = cp.toSet -- existing.map(_.jar) ++ toDelete.map(_.jar)
     val uploaded = toUpload.map { jar =>
-      val uploadedLib = client.uploadJar(jar.getName, jar, folder)
-      new UploadedLibrary(jar.getName, jar, uploadedLib.id)
+      val uploadedLib = client.uploadJar(projectName, jar.getName, jar)
+      new UploadedLibrary(jar.getName, jar, uploadedLib)
     }.toSeq
     (uploaded, toDelete)
   }
@@ -159,10 +159,10 @@ object DatabricksPlugin extends AutoPlugin {
   private lazy val uploadImpl: Def.Initialize[Task[(Seq[UploadedLibrary], Seq[UploadedLibrary])]] =
     Def.task {
       val client = dbcApiClient.value
-      val folder = dbcLibraryPath.value
+      // val folder = dbcLibraryPath.value
       val existing = existingLibraries.value
       val classpath = dbcClasspath.value
-      uploadImpl1(client, folder, classpath, existing)
+      uploadImpl1(client, name.value, classpath, existing)
     }
 
   private lazy val deployImpl: Def.Initialize[Task[Unit]] = Def.taskDyn {

--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -139,7 +139,7 @@ object DatabricksPlugin extends AutoPlugin {
 
   private def uploadImpl1(
       client: DatabricksHttp,
-      projectName: String,
+      folder: String,
       cp: Seq[File],
       existing: Seq[UploadedLibrary]): (Seq[UploadedLibrary], Seq[UploadedLibrary]) = {
     // TODO: try to figure out dependencies with changed versions
@@ -148,8 +148,8 @@ object DatabricksPlugin extends AutoPlugin {
     // Either upload the newer SNAPSHOT versions, or everything, because they don't exist yet.
       val toUpload = cp.toSet -- existing.map(_.jar) ++ toDelete.map(_.jar)
     val uploaded = toUpload.map { jar =>
-      val uploadedLib = client.uploadJar(projectName, jar.getName, jar)
-      new UploadedLibrary(jar.getName, jar, uploadedLib)
+      val uploadedLib = client.uploadJar(jar.getName, jar, folder)
+      new UploadedLibrary(jar.getName, jar, uploadedLib.id)
     }.toSeq
     (uploaded, toDelete)
   }
@@ -159,10 +159,10 @@ object DatabricksPlugin extends AutoPlugin {
   private lazy val uploadImpl: Def.Initialize[Task[(Seq[UploadedLibrary], Seq[UploadedLibrary])]] =
     Def.task {
       val client = dbcApiClient.value
-      // val folder = dbcLibraryPath.value
+      val folder = dbcLibraryPath.value
       val existing = existingLibraries.value
       val classpath = dbcClasspath.value
-      uploadImpl1(client, name.value, classpath, existing)
+      uploadImpl1(client, folder, classpath, existing)
     }
 
   private lazy val deployImpl: Def.Initialize[Task[Unit]] = Def.taskDyn {

--- a/src/main/scala/sbtdatabricks/util/Requests.scala
+++ b/src/main/scala/sbtdatabricks/util/Requests.scala
@@ -16,33 +16,203 @@
 
 package sbtdatabricks.util
 
+import java.io.File
+
+import scala.collection.JavaConversions._
+
+import org.apache.http.client.entity.UrlEncodedFormEntity
+import org.apache.http.client.methods.{HttpGet, HttpPost, HttpRequestBase}
+import org.apache.http.client.utils.URLEncodedUtils
+import org.apache.http.entity.StringEntity
+import org.apache.http.entity.mime.MultipartEntity
+import org.apache.http.entity.mime.content.{FileBody, StringBody}
+import org.apache.http.message.BasicNameValuePair
+
+import sbtdatabricks.{Cluster, ContextId, DatabricksHttp, DBApiEndpoints}
+
 // scalastyle:off
 private[sbtdatabricks] object requests {
 // scalastyle:on
+  import DBApiEndpoints._
+  import DatabricksHttp.mapper
 
-  sealed trait DBApiRequest
+  sealed trait DBApiRequest {
+    def apiVersion: String
+
+    final def getRequest(baseEndpoint: String): HttpRequestBase = {
+      getRequestInternal(getApiUrl(baseEndpoint))
+    }
+
+    protected def getRequestInternal(endpoint: String): HttpRequestBase
+
+    private[this] def getApiUrl(endpoint: String): String = {
+      val untilApi = endpoint.indexOf("/api")
+      if (untilApi < 0) {
+        // url provided without /api/$apiVersion
+        endpoint.stripSuffix("/") + "/api/" + apiVersion
+      } else {
+        endpoint.take(untilApi) + "/api/" + apiVersion
+      }
+    }
+  }
+
+  sealed trait DBApiV1Request extends DBApiRequest {
+    override def apiVersion: String = "1.2"
+  }
+
+  sealed trait DBApiV2Request extends DBApiRequest {
+    override def apiVersion: String = "2.0"
+  }
+
+  ///////////////////////////////////////////
+  // Execution Context Requests
+  ///////////////////////////////////////////
 
   /** Request sent to create a Spark Context */
-  private[sbtdatabricks] case class CreateContextRequestV1(
-      language: String,
-      clusterId: String) extends DBApiRequest
+  case class CreateContextRequestV1(language: String, clusterId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      setJsonRequest(this, new HttpPost(endpoint + CONTEXT_CREATE))
+    }
+  }
+
+  /** Request sent to create a Spark Context */
+  case class CheckContextRequestV1(contextId: ContextId, cluster: Cluster) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val form = URLEncodedUtils.format(List(new BasicNameValuePair("clusterId", cluster.id),
+        new BasicNameValuePair("contextId", contextId.id)), "utf-8")
+      new HttpGet(endpoint + CONTEXT_STATUS + "?" + form)
+    }
+  }
 
   /** Request sent to destroy a Spark Context */
-  private[sbtdatabricks] case class DestroyContextRequestV1(
-      clusterId: String,
-      contextId: String) extends DBApiRequest
+  case class DestroyContextRequestV1(clusterId: String, contextId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      setJsonRequest(this, new HttpPost(endpoint + CONTEXT_DESTROY))
+    }
+  }
+
+  ///////////////////////////////////////////
+  // Command Related Requests
+  ///////////////////////////////////////////
 
   /** Request sent to cancel a command */
-  private[sbtdatabricks] case class CancelCommandRequestV1(
+  case class CancelCommandRequestV1(
       clusterId: String,
       contextId: String,
-      commandId: String) extends DBApiRequest
+      commandId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      setJsonRequest(this, new HttpPost(endpoint + COMMAND_CANCEL))
+    }
+  }
+
+  /** Request sent to check the status of a command */
+  case class CheckCommandRequestV1(
+      clusterId: String,
+      contextId: String,
+      commandId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val form = URLEncodedUtils.format(List(new BasicNameValuePair("clusterId", clusterId),
+        new BasicNameValuePair("contextId", contextId),
+        new BasicNameValuePair("commandId", commandId)), "utf-8")
+      new HttpGet(endpoint + COMMAND_STATUS + "?" + form)
+    }
+  }
+
+  /** Request sent to check the status of a command */
+  case class ExecuteCommandRequestV1(
+      language: String,
+      clusterId: String,
+      contextId: String,
+      commandFile: File) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val post = new HttpPost(endpoint + COMMAND_EXECUTE)
+      val entity = new MultipartEntity()
+      entity.addPart("language", new StringBody(language))
+      entity.addPart("clusterId", new StringBody(clusterId))
+      entity.addPart("contextId", new StringBody(contextId))
+      entity.addPart("command", new FileBody(commandFile))
+      post.setEntity(entity)
+      post
+    }
+  }
+
+  ///////////////////////////////////////////
+  // Library Requests
+  ///////////////////////////////////////////
 
   /** Request sent to attach a library to a cluster */
-  private[sbtdatabricks] case class LibraryAttachRequestV1(
-      libraryId: String,
-      clusterId: String) extends DBApiRequest
+  case class LibraryAttachRequestV1(libraryId: String, clusterId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      setJsonRequest(this, new HttpPost(endpoint + LIBRARY_ATTACH))
+    }
+  }
+
+  case class DeleteLibraryRequestV1(libraryId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val post = new HttpPost(endpoint + LIBRARY_DELETE)
+      val form = List(new BasicNameValuePair("libraryId", libraryId))
+      post.setEntity(new UrlEncodedFormEntity(form))
+      post
+    }
+  }
+
+  case class ListLibrariesRequestV1() extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      new HttpGet(endpoint + LIBRARY_LIST)
+    }
+  }
+
+  case class GetLibraryStatusRequestV1(libraryId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val form =
+        URLEncodedUtils.format(List(new BasicNameValuePair("libraryId", libraryId)), "utf-8")
+      new HttpGet(endpoint + LIBRARY_STATUS + "?" + form)
+    }
+  }
+
+  case class UploadLibraryRequest(path: String, file: File) extends DBApiV2Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val post = new HttpPost(endpoint + DBFS_PUT)
+      val entity = new MultipartEntity()
+      entity.addPart("path", new StringBody(path))
+      entity.addPart("overwrite", new StringBody("true"))
+      entity.addPart("contents", new FileBody(file))
+      post.setEntity(entity)
+      post
+    }
+  }
+
+  ///////////////////////////////////////////
+  // Cluster Requests
+  ///////////////////////////////////////////
 
   /** Request sent to restart a cluster */
-  private[sbtdatabricks] case class RestartClusterRequestV1(clusterId: String) extends DBApiRequest
+  case class RestartClusterRequestV1(clusterId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      setJsonRequest(this, new HttpPost(endpoint + CLUSTER_RESTART))
+    }
+  }
+
+  /** Request sent to get the status of a cluster */
+  case class GetClusterStatusRequestV1(clusterId: String) extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      val form =
+        URLEncodedUtils.format(List(new BasicNameValuePair("clusterId", clusterId)), "utf-8")
+      new HttpGet(endpoint + CLUSTER_INFO + "?" + form)
+    }
+  }
+
+  /** Request sent to get the status of a cluster */
+  case class ListClustersRequestV1() extends DBApiV1Request {
+    override def getRequestInternal(endpoint: String): HttpRequestBase = {
+      new HttpGet(endpoint + CLUSTER_LIST)
+    }
+  }
+
+  private[this] def setJsonRequest(contents: DBApiRequest, post: HttpPost): HttpPost = {
+    val form = new StringEntity(mapper.writeValueAsString(contents))
+    form.setContentType("application/json")
+    post.setEntity(form)
+    post
+  }
 }

--- a/src/sbt-test/sbt-databricks/rest-calls/project/plugins.sbt
+++ b/src/sbt-test/sbt-databricks/rest-calls/project/plugins.sbt
@@ -7,6 +7,6 @@
   if (pluginVersion == null)
     throw new RuntimeException(
       """|The system property 'plugin.version' is not defined.
-                                 |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
+         |Specify this property using the scriptedLaunchOpts -D.""".stripMargin)
   else addSbtPlugin("com.databricks" % "sbt-databricks" % pluginVersion)
 }


### PR DESCRIPTION
The Apache commons HttpClient started braking with multipart/form-data requests, making commands like: `dbcUpload`, `dbcDeploy`, `dbcExecuteCommand` unusable. This PR changes the http client from apache commons to jetty 9.