### PR TITLE
Much simpler fix for Issue #30

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: scala
 scala:
   - 2.10.4
 jdk:
+  - oraclejdk8
   - openjdk7
   - openjdk6
 sudo: false

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.databricks"
 
 name := "sbt-databricks"
 
-version := "0.1.7-SNAPSHOT"
+version := "0.1.5-SNAPSHOT"
 
 scalaVersion := "2.10.4"
 

--- a/build.sbt
+++ b/build.sbt
@@ -6,7 +6,7 @@ organization := "com.databricks"
 
 name := "sbt-databricks"
 
-version := "0.1.5-SNAPSHOT"
+version := "0.1.7-SNAPSHOT"
 
 scalaVersion := "2.10.4"
 

--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -102,6 +102,8 @@ class DatabricksHttp(
     entity.addPart("folder", new StringBody(folder))
     entity.addPart("uri", new FileBody(file))
     post.setEntity(entity)
+    // jetty closes the connection if we don't set this header
+    post.addHeader("Expect", "100-continue")
     val response = client.execute(post)
     val stringResponse = handleResponse(response)
     mapper.readValue[UploadedLibraryId](stringResponse)
@@ -271,7 +273,8 @@ class DatabricksHttp(
     entity.addPart("contextId", new StringBody(contextId.id))
     entity.addPart("command", new FileBody(commandFile))
     post.setEntity(entity)
-
+    // jetty closes the connection if we don't set this header
+    post.addHeader("Expect", "100-continue")
     val response = client.execute(post)
     val responseString = handleResponse(response).trim
     mapper.readValue[CommandId](responseString)


### PR DESCRIPTION
Jetty apparently expects a header to keep the connection. Once we pass this header in for multipart connections, the connection is not abruptly closed.