### PR TITLE
[WIP] Porting dbcDeploy on API v2.0

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -6,16 +6,18 @@ organization := "com.databricks"
 
 name := "sbt-databricks"
 
-version := "0.1.6-SNAPSHOT"
+version := "0.1.7-SNAPSHOT"
 
-scalaVersion := "2.10.4"
+scalaVersion := "2.10.7"
+
+val httpCompsV = "4.5.5"
 
 libraryDependencies ++= Seq(
-    "org.apache.httpcomponents" % "httpclient" % "4.3.3",
-    "org.apache.httpcomponents" % "httpmime" % "4.3.3",
-    "org.apache.httpcomponents" % "httpclient-cache" % "4.3.3",
-    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.5.3",
-    "commons-fileupload" % "commons-fileupload" % "1.3")
+    "org.apache.httpcomponents" % "httpclient" % httpCompsV,
+    "org.apache.httpcomponents" % "httpmime" % httpCompsV,
+    "org.apache.httpcomponents" % "httpclient-cache" % httpCompsV,
+    "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.4",
+    "commons-fileupload" % "commons-fileupload" % "1.3.3")
 
 version in ThisBuild := s"${version.value}"
 

--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,5 @@
 import bintray.Keys._
+import sbt.Resolver
 
 sbtPlugin := true
 
@@ -10,6 +11,8 @@ version := "0.1.7-SNAPSHOT"
 
 scalaVersion := "2.10.7"
 
+resolvers += Resolver.bintrayRepo("maxgekk", "maven")
+
 val httpCompsV = "4.5.5"
 
 libraryDependencies ++= Seq(
@@ -17,7 +20,9 @@ libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpmime" % httpCompsV,
     "org.apache.httpcomponents" % "httpclient-cache" % httpCompsV,
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.4",
-    "commons-fileupload" % "commons-fileupload" % "1.3.3")
+    "commons-fileupload" % "commons-fileupload" % "1.3.3",
+    "default" %% "libricks" % "0.4"
+)
 
 version in ThisBuild := s"${version.value}"
 

--- a/build.sbt
+++ b/build.sbt
@@ -21,7 +21,7 @@ libraryDependencies ++= Seq(
     "org.apache.httpcomponents" % "httpclient-cache" % httpCompsV,
     "com.fasterxml.jackson.module" %% "jackson-module-scala" % "2.9.4",
     "commons-fileupload" % "commons-fileupload" % "1.3.3",
-    "default" %% "libricks" % "0.4"
+    "default" %% "libricks" % "0.5-SNAPSHOT"
 )
 
 version in ThisBuild := s"${version.value}"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.8
+sbt.version=0.13.17

--- a/src/main/scala/sbtdatabricks/DatabricksHttp.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttp.scala
@@ -18,30 +18,29 @@ package sbtdatabricks
 
 import java.io.PrintStream
 
-import scala.util.control.NonFatal
+import com.databricks.Shard
 
+import scala.util.control.NonFatal
 import com.fasterxml.jackson.databind.ObjectMapper
 import com.fasterxml.jackson.module.scala.DefaultScalaModule
 import com.fasterxml.jackson.module.scala.experimental.ScalaObjectMapper
-
-import org.apache.http.{HttpEntity, StatusLine, HttpResponse}
+import org.apache.http.{HttpEntity, HttpResponse, StatusLine}
 import org.apache.http.auth.{AuthScope, UsernamePasswordCredentials}
-import org.apache.http.client.{HttpResponseException, HttpClient}
+import org.apache.http.client.{HttpClient, HttpResponseException}
 import org.apache.http.client.entity.UrlEncodedFormEntity
 import org.apache.http.client.methods._
 import org.apache.http.client.utils.URLEncodedUtils
-import org.apache.http.conn.ssl.{SSLConnectionSocketFactory, TrustSelfSignedStrategy, SSLContextBuilder}
+import org.apache.http.conn.ssl.{SSLConnectionSocketFactory, SSLContextBuilder, TrustSelfSignedStrategy}
 import org.apache.http.entity.StringEntity
 import org.apache.http.entity.mime.MultipartEntity
 import org.apache.http.entity.mime.content.{FileBody, StringBody}
 import org.apache.http.impl.client.{BasicCredentialsProvider, HttpClients}
 import org.apache.http.message.BasicNameValuePair
 import org.apache.http.util.EntityUtils
-
 import sbt._
+
 import scala.collection.JavaConversions._
 import scala.collection.mutable.ArrayBuffer
-
 import sbtdatabricks.DatabricksPlugin.ClusterName
 import sbtdatabricks.DatabricksPlugin.autoImport.DBC_ALL_CLUSTERS
 import sbtdatabricks.util.requests._
@@ -498,7 +497,14 @@ object DatabricksHttp {
       username: String,
       password: String): DatabricksHttp = {
     val cli = DatabricksHttp.getApiClient(username, password)
-    new DatabricksHttp(endpoint, cli)
+    val shardClient = Shard(endpoint)
+      .username(username).password(password)
+      .connect
+    new DatabricksHttpV2(
+      shardClient,
+      endpoint + "/api/1.2",
+      cli
+    )
   }
 
   /** Returns a mock testClient */

--- a/src/main/scala/sbtdatabricks/DatabricksHttpV2.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttpV2.scala
@@ -1,0 +1,51 @@
+/*
+ * Copyright 2018 Databricks
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package sbtdatabricks
+
+import java.io.PrintStream
+
+import com.databricks.{Jar, ShardClient}
+import org.apache.http.client.HttpClient
+import java.io.File
+
+class DatabricksHttpV2(
+    shardClient: ShardClient,
+    _endpoint: String,
+    httpClientV1: HttpClient,
+    outputStream: PrintStream = System.out
+  ) extends DatabricksHttp(_endpoint, httpClientV1, outputStream) {
+
+  override private[sbtdatabricks] def uploadJar(
+    name: String,
+    file: File,
+    folder: String
+  ): UploadedLibraryId = {
+    val fileName = file.getName
+    val dstPath = folder + "/" + fileName
+    shardClient.fs.upload(file.getCanonicalPath, dstPath, overwrite = true)
+
+    UploadedLibraryId(dstPath)
+  }
+
+  override private[sbtdatabricks] def attachToCluster(
+    library: UploadedLibrary,
+    cluster: Cluster): ClusterId = {
+    shardClient.lib.install(cluster.id, List(Jar(library.id)))
+
+    ClusterId(cluster.id)
+  }
+}

--- a/src/main/scala/sbtdatabricks/DatabricksHttpV2.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksHttpV2.scala
@@ -36,6 +36,7 @@ class DatabricksHttpV2(
   ): UploadedLibraryId = {
     val fileName = file.getName
     val dstPath = folder + "/" + fileName
+    outputStream.println(s"Upload jar: ${file.getCanonicalPath} to ${dstPath}")
     shardClient.fs.upload(file.getCanonicalPath, dstPath, overwrite = true)
 
     UploadedLibraryId(dstPath)
@@ -44,7 +45,8 @@ class DatabricksHttpV2(
   override private[sbtdatabricks] def attachToCluster(
     library: UploadedLibrary,
     cluster: Cluster): ClusterId = {
-    shardClient.lib.install(cluster.id, List(Jar(library.id)))
+    outputStream.println(s"Install ${library.remotePath} to ${cluster.id}")
+    shardClient.lib.install(cluster.id, List(Jar(library.remotePath)))
 
     ClusterId(cluster.id)
   }

--- a/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
+++ b/src/main/scala/sbtdatabricks/DatabricksPlugin.scala
@@ -491,7 +491,15 @@ object DatabricksPlugin extends AutoPlugin {
 case class ErrorResponse(error: String)
 sealed trait Responses
 case class UploadedLibraryId(id: String)
-case class UploadedLibrary(name: String, jar: File, id: String)
+case class UploadedLibrary(name: String, jar: File, id: String) {
+  def remotePath: String = {
+    if (id.startsWith("dbfs:") || id.startsWith("s3:")) {
+      id
+    } else {
+      "dbfs:" + id
+    }
+  }
+}
 case class Cluster(
     name: String,
     id: String,


### PR DESCRIPTION
The uploadJar() and attachToCluster() methods are overwritten and ported on the Libricks library: https://github.com/MaxGekk/libricks. The PR: https://github.com/MaxGekk/libricks/pull/10 to the library has changes required by this PR.